### PR TITLE
fix: wrap changeset version command in sh to support && operator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: npx changeset version && node scripts/sync-version.cjs
+          version: sh -c "npx changeset version && node scripts/sync-version.cjs"
           publish: npm publish --ignore-scripts --registry ${{ secrets.STAGING_VERDACCIO_URL }}
           title: "Version Packages"
           commit: "chore: version packages"


### PR DESCRIPTION
Closes Coongro/Coongro#289

## Changes
- Fix release workflow: wrap `npx changeset version && node scripts/sync-version.cjs` in `sh -c "..."` so el operador `&&` funciona correctamente en changesets/action

## Test plan
- [ ] CI en staging crea PR "Version Packages" correctamente
- [ ] Al mergear el PR, publica a Verdaccio staging