### PR TITLE
feat: create git tag after production publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,12 @@ jobs:
           echo "//${{ secrets.PROD_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.PROD_VERDACCIO_TOKEN }}" >> .npmrc
           npm publish --ignore-scripts
 
+      - name: Create tag
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
       - name: Summary
         run: |
           VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
Adds tag creation to publish workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the publish workflow to automatically create and push version tags during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->