### PR TITLE
ci: sync develop with staging after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,13 @@ jobs:
     name: Version or Publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -41,3 +46,23 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           NAME=$(node -p "require('./package.json').name")
           echo "### Published $NAME@$VERSION to staging" >> $GITHUB_STEP_SUMMARY
+
+      - name: Sync develop with staging
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout develop
+          git merge staging --no-edit || {
+            git merge --abort
+            gh pr create \
+              --base develop \
+              --head staging \
+              --title "sync: merge staging into develop (conflicts)" \
+              --body "Merge automático de staging a develop falló por conflictos. Resolver manualmente."
+            echo "::warning::Conflictos al sincronizar develop. PR creado."
+            exit 0
+          }
+          git push origin develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #28

## Changes
- Add `permissions: contents: write` and `pull-requests: write` to release job
- Add `fetch-depth: 0` to checkout step (needed to access develop branch)
- Add "Sync develop with staging" step that runs after successful publish
- On merge conflict, automatically creates a PR for manual resolution

## Testing
- [ ] Verify workflow syntax is valid
- [ ] Trigger a staging publish and confirm develop is synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)