### PR TITLE
feat: group contact form fields into sections with icons

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -44,6 +44,15 @@ const BASE_FIELDS: FieldDef[] = [
   { key: 'notes', label: 'Notas', type: 'textarea', placeholder: 'Notas adicionales...' },
 ];
 
+/** Secciones con iconos para agrupar los campos visualmente */
+const FIELD_SECTIONS: Array<{ title: string; icon: string; keys: string[] }> = [
+  { title: 'Información personal', icon: 'User', keys: ['type', 'name'] },
+  { title: 'Contacto', icon: 'Phone', keys: ['phone', 'email'] },
+  { title: 'Documento', icon: 'FileCheck', keys: ['document_type', 'document_number'] },
+  { title: 'Dirección', icon: 'MapPin', keys: ['address'] },
+  { title: 'Notas', icon: 'FileText', keys: ['notes'] },
+];
+
 export function ContactForm(props: ContactFormProps) {
   const {
     contactId,
@@ -131,24 +140,56 @@ export function ContactForm(props: ContactFormProps) {
     });
   }
 
+  // Agrupar campos por sección; los extra van al final sin sección
+  const sectionedKeys = new Set(FIELD_SECTIONS.flatMap((s) => s.keys));
+  const extraVisible = allFields.filter((f) => !sectionedKeys.has(f.key));
+
+  function renderFieldEl(field: FieldDef) {
+    return React.createElement(
+      'div',
+      { key: field.key, className: 'flex flex-col gap-1.5' },
+      React.createElement(
+        UI.Label,
+        null,
+        field.label,
+        field.required && React.createElement('span', { className: 'text-cg-danger ml-0.5' }, '*')
+      ),
+      renderField(field, formData[field.key], (v) => handleChange(field.key, v))
+    );
+  }
+
+  function renderSectionHeader(title: string, icon: string) {
+    return React.createElement(
+      'h3',
+      {
+        key: `header-${icon}`,
+        className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted',
+      },
+      React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
+      title
+    );
+  }
+
   return React.createElement(
     'form',
-    { onSubmit: handleSubmit, className: `flex flex-col gap-4 ${className}` },
+    { onSubmit: handleSubmit, className: `flex flex-col gap-6 ${className}` },
 
-    // Campos
-    allFields.map((field) =>
-      React.createElement(
+    // Campos agrupados por sección
+    ...FIELD_SECTIONS.map((section) => {
+      const sectionFields = section.keys
+        .map((k) => allFields.find((f) => f.key === k))
+        .filter((f): f is FieldDef => Boolean(f));
+      if (sectionFields.length === 0) return null;
+      return React.createElement(
         'div',
-        { key: field.key, className: 'flex flex-col gap-1.5' },
-        React.createElement(
-          UI.Label,
-          null,
-          field.label,
-          field.required && React.createElement('span', { className: 'text-cg-danger ml-0.5' }, '*')
-        ),
-        renderField(field, formData[field.key], (v) => handleChange(field.key, v))
-      )
-    ),
+        { key: section.title, className: 'flex flex-col gap-3' },
+        renderSectionHeader(section.title, section.icon),
+        ...sectionFields.map(renderFieldEl)
+      );
+    }),
+
+    // Campos extra de bloques (sin sección)
+    ...extraVisible.map(renderFieldEl),
 
     // Toggle activo
     React.createElement(

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -53,6 +53,30 @@ const FIELD_SECTIONS: Array<{ title: string; icon: string; keys: string[] }> = [
   { title: 'Notas', icon: 'FileText', keys: ['notes'] },
 ];
 
+/** Keys de campos base que pertenecen a alguna sección */
+const BASE_SECTIONED_KEYS = new Set(
+  FIELD_SECTIONS.flatMap((s) => s.keys).filter((k) => BASE_FIELDS.some((f) => f.key === k))
+);
+
+/** Header de sección con icono (sin dependencias de closure) */
+function renderSectionHeader(title: string, icon: string) {
+  return React.createElement(
+    'h3',
+    {
+      key: `header-${title}`,
+      className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted',
+    },
+    React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
+    title
+  );
+}
+
+function getSubmitLabel(isSaving: boolean, isEdit: boolean): string {
+  if (isSaving) return 'Guardando...';
+  if (isEdit) return 'Actualizar';
+  return 'Crear contacto';
+}
+
 export function ContactForm(props: ContactFormProps) {
   const {
     contactId,
@@ -140,9 +164,8 @@ export function ContactForm(props: ContactFormProps) {
     });
   }
 
-  // Agrupar campos por sección; los extra van al final sin sección
-  const sectionedKeys = new Set(FIELD_SECTIONS.flatMap((s) => s.keys));
-  const extraVisible = allFields.filter((f) => !sectionedKeys.has(f.key));
+  // Campos extra de bloques que no pertenecen a ninguna sección base
+  const unsectionedFields = allFields.filter((f) => !BASE_SECTIONED_KEYS.has(f.key));
 
   function renderFieldEl(field: FieldDef) {
     return React.createElement(
@@ -155,18 +178,6 @@ export function ContactForm(props: ContactFormProps) {
         field.required && React.createElement('span', { className: 'text-cg-danger ml-0.5' }, '*')
       ),
       renderField(field, formData[field.key], (v) => handleChange(field.key, v))
-    );
-  }
-
-  function renderSectionHeader(title: string, icon: string) {
-    return React.createElement(
-      'h3',
-      {
-        key: `header-${icon}`,
-        className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted',
-      },
-      React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
-      title
     );
   }
 
@@ -186,10 +197,10 @@ export function ContactForm(props: ContactFormProps) {
         renderSectionHeader(section.title, section.icon),
         ...sectionFields.map(renderFieldEl)
       );
-    }),
+    }).filter(Boolean),
 
     // Campos extra de bloques (sin sección)
-    ...extraVisible.map(renderFieldEl),
+    ...unsectionedFields.map(renderFieldEl),
 
     // Toggle activo
     React.createElement(
@@ -213,7 +224,7 @@ export function ContactForm(props: ContactFormProps) {
           disabled: isSaving || !formData.name,
           className: 'flex-1',
         },
-        isSaving ? 'Guardando...' : isEdit ? 'Actualizar' : 'Crear contacto'
+        getSubmitLabel(isSaving, isEdit)
       ),
       onCancel &&
         React.createElement(


### PR DESCRIPTION
## Summary
- Agrupa los campos del formulario de contacto en secciones visuales con iconos (info personal, contacto, documento, dirección, notas)
- Usa `DynamicIcon` para los headers de sección
- Campos extra de bloques se renderizan al final sin sección

## Changes
- `FIELD_SECTIONS` constante con título, icono y keys por sección
- `renderSectionHeader()` y `getSubmitLabel()` extraídos a scope de módulo
- `BASE_SECTIONED_KEYS` solo incluye keys de campos base (evita que extra fields con keys duplicados desaparezcan)
- Filtrado de nulls antes del spread en `createElement`

## Test plan
- [ ] Verificar que el formulario de crear contacto muestra las 5 secciones con iconos
- [ ] Verificar que el formulario de editar contacto carga datos correctamente
- [ ] Verificar que campos extra de otros bloques aparecen al final
- [ ] Verificar responsive en móvil

Closes Coongro/contacts#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)