### PR TITLE
Promote develop → staging

### DIFF
--- a/.changeset/migrate-contacts-table-datatable.md
+++ b/.changeset/migrate-contacts-table-datatable.md
@@ -1,0 +1,5 @@
+---
+"@coongro/contacts": minor
+---
+
+Migrate ContactsTable to DataTable with mobile card view (mobileRender)

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -44,6 +44,39 @@ const BASE_FIELDS: FieldDef[] = [
   { key: 'notes', label: 'Notas', type: 'textarea', placeholder: 'Notas adicionales...' },
 ];
 
+/** Secciones con iconos para agrupar los campos visualmente */
+const FIELD_SECTIONS: Array<{ title: string; icon: string; keys: string[] }> = [
+  { title: 'Información personal', icon: 'User', keys: ['type', 'name'] },
+  { title: 'Contacto', icon: 'Phone', keys: ['phone', 'email'] },
+  { title: 'Documento', icon: 'FileCheck', keys: ['document_type', 'document_number'] },
+  { title: 'Dirección', icon: 'MapPin', keys: ['address'] },
+  { title: 'Notas', icon: 'FileText', keys: ['notes'] },
+];
+
+/** Keys de campos base que pertenecen a alguna sección */
+const BASE_SECTIONED_KEYS = new Set(
+  FIELD_SECTIONS.flatMap((s) => s.keys).filter((k) => BASE_FIELDS.some((f) => f.key === k))
+);
+
+/** Header de sección con icono (sin dependencias de closure) */
+function renderSectionHeader(title: string, icon: string) {
+  return React.createElement(
+    'h3',
+    {
+      key: `header-${title}`,
+      className: 'flex items-center gap-2 text-sm font-medium text-cg-text-muted',
+    },
+    React.createElement(UI.DynamicIcon, { icon, size: 14, className: 'text-cg-text-muted' }),
+    title
+  );
+}
+
+function getSubmitLabel(isSaving: boolean, isEdit: boolean): string {
+  if (isSaving) return 'Guardando...';
+  if (isEdit) return 'Actualizar';
+  return 'Crear contacto';
+}
+
 export function ContactForm(props: ContactFormProps) {
   const {
     contactId,
@@ -131,24 +164,43 @@ export function ContactForm(props: ContactFormProps) {
     });
   }
 
+  // Campos extra de bloques que no pertenecen a ninguna sección base
+  const unsectionedFields = allFields.filter((f) => !BASE_SECTIONED_KEYS.has(f.key));
+
+  function renderFieldEl(field: FieldDef) {
+    return React.createElement(
+      'div',
+      { key: field.key, className: 'flex flex-col gap-1.5' },
+      React.createElement(
+        UI.Label,
+        null,
+        field.label,
+        field.required && React.createElement('span', { className: 'text-cg-danger ml-0.5' }, '*')
+      ),
+      renderField(field, formData[field.key], (v) => handleChange(field.key, v))
+    );
+  }
+
   return React.createElement(
     'form',
-    { onSubmit: handleSubmit, className: `flex flex-col gap-4 ${className}` },
+    { onSubmit: handleSubmit, className: `flex flex-col gap-6 ${className}` },
 
-    // Campos
-    allFields.map((field) =>
-      React.createElement(
+    // Campos agrupados por sección
+    ...FIELD_SECTIONS.map((section) => {
+      const sectionFields = section.keys
+        .map((k) => allFields.find((f) => f.key === k))
+        .filter((f): f is FieldDef => Boolean(f));
+      if (sectionFields.length === 0) return null;
+      return React.createElement(
         'div',
-        { key: field.key, className: 'flex flex-col gap-1.5' },
-        React.createElement(
-          UI.Label,
-          null,
-          field.label,
-          field.required && React.createElement('span', { className: 'text-cg-danger ml-0.5' }, '*')
-        ),
-        renderField(field, formData[field.key], (v) => handleChange(field.key, v))
-      )
-    ),
+        { key: section.title, className: 'flex flex-col gap-3' },
+        renderSectionHeader(section.title, section.icon),
+        ...sectionFields.map(renderFieldEl)
+      );
+    }).filter(Boolean),
+
+    // Campos extra de bloques (sin sección)
+    ...unsectionedFields.map(renderFieldEl),
 
     // Toggle activo
     React.createElement(
@@ -172,7 +224,7 @@ export function ContactForm(props: ContactFormProps) {
           disabled: isSaving || !formData.name,
           className: 'flex-1',
         },
-        isSaving ? 'Guardando...' : isEdit ? 'Actualizar' : 'Crear contacto'
+        getSubmitLabel(isSaving, isEdit)
       ),
       onCancel &&
         React.createElement(

--- a/src/components/ContactsTable.tsx
+++ b/src/components/ContactsTable.tsx
@@ -1,13 +1,14 @@
 /**
  * Tabla de contactos con búsqueda, filtros y paginación.
  * Extensible via extraColumns, extraActions, extraFilters.
+ * Usa DataTable de ui-components con mobileRender para cards en móvil.
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useContacts } from '../hooks/useContacts.js';
 import { formatType } from '../lib/formatType.js';
 import type { ContactsTableProps, ColumnDef } from '../types/components.js';
-import type { SortDirection } from '../types/filters.js';
+import type { Contact } from '../types/contact.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -42,7 +43,6 @@ export function ContactsTable(props: ContactsTableProps) {
     columns,
     extraColumns = [],
     extraActions = [],
-    extraFilters: _extraFilters = [],
     onRowClick,
     selectable = false,
     onSelectionChange,
@@ -51,18 +51,7 @@ export function ContactsTable(props: ContactsTableProps) {
     emptyMessage = 'No se encontraron contactos',
   } = props;
 
-  const {
-    data,
-    loading,
-    error,
-    setFilters,
-    setSort,
-    pagination,
-    nextPage,
-    prevPage,
-    goToPage,
-    refetch,
-  } = useContacts({
+  const { data, loading, error, setFilters, setSort, pagination, goToPage, refetch } = useContacts({
     ...initialFilters,
     pageSize,
   });
@@ -70,17 +59,31 @@ export function ContactsTable(props: ContactsTableProps) {
   const [searchValue, setSearchValue] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [activeTypeFilter, setActiveTypeFilter] = useState<string>(initialFilters?.type ?? '');
-  const [sortKey, setSortKey] = useState<string>('');
-  const [sortDir, setSortDir] = useState<SortDirection>('asc');
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc' | null>(null);
 
-  const allColumns = useMemo(
-    () => [...(columns ?? DEFAULT_COLUMNS), ...extraColumns],
-    [columns, extraColumns]
-  );
+  // Columnas en formato DataTable
+  const dtColumns = useMemo(() => {
+    const base = columns ?? DEFAULT_COLUMNS;
+    return [...base, ...extraColumns].map((col) => ({
+      ...col,
+      sortable: SORTABLE_KEYS.has(col.key),
+    }));
+  }, [columns, extraColumns]);
+
+  // Acciones en formato DataTable
+  const dtActions = useMemo(() => {
+    if (extraActions.length === 0) return undefined;
+    return extraActions.map((a) => ({
+      label: a.label,
+      onClick: a.onClick,
+      variant: a.variant as 'ghost' | 'destructive' | undefined,
+      hidden: a.hidden,
+    }));
+  }, [extraActions]);
 
   const handleSearch = useCallback(
-    (e: { target: { value: string } }) => {
-      const value = e.target.value;
+    (value: string) => {
       setSearchValue(value);
       setFilters({
         query: value || undefined,
@@ -102,287 +105,102 @@ export function ContactsTable(props: ContactsTableProps) {
   );
 
   const handleSort = useCallback(
-    (key: string) => {
+    (key: string, direction: 'asc' | 'desc' | null) => {
       if (!SORTABLE_KEYS.has(key)) return;
-      const newDir: SortDirection = sortKey === key && sortDir === 'asc' ? 'desc' : 'asc';
-      setSortKey(key);
-      setSortDir(newDir);
-      setSort(key, newDir);
+      setSortKey(direction ? key : null);
+      setSortDir(direction);
+      setSort(key, direction ?? 'asc');
     },
-    [sortKey, sortDir, setSort]
+    [setSort]
   );
 
-  const toggleSelection = useCallback(
-    (id: string) => {
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        onSelectionChange?.(Array.from(next));
-        return next;
-      });
+  const handleSelectionChange = useCallback(
+    (ids: Set<string>) => {
+      setSelectedIds(ids);
+      onSelectionChange?.(Array.from(ids));
     },
     [onSelectionChange]
   );
 
-  const toggleAllSelection = useCallback(() => {
-    setSelectedIds((prev) => {
-      const allSelected = data.every((c) => prev.has(c.id));
-      const next = allSelected ? new Set<string>() : new Set(data.map((c) => c.id));
-      onSelectionChange?.(Array.from(next));
-      return next;
-    });
-  }, [data, onSelectionChange]);
-
-  /** Mapeo de sort direction para TableHead */
-  const getSortDirection = (colKey: string): false | 'asc' | 'desc' | undefined => {
-    if (!SORTABLE_KEYS.has(colKey)) return undefined;
-    if (sortKey === colKey) return sortDir as 'asc' | 'desc';
-    return false;
-  };
-
-  const totalColSpan = (selectable ? 1 : 0) + allColumns.length + (extraActions.length > 0 ? 1 : 0);
-
-  // --- Render ---
-
-  if (error) {
-    return React.createElement(UI.ErrorDisplay, {
-      title: 'Error',
-      message: error,
-      onRetry: () => refetch(),
-    });
-  }
-
-  return React.createElement(
-    'div',
-    { className: `flex flex-col gap-4 ${className}` },
-
-    // Barra de búsqueda y filtros
-    React.createElement(
-      'div',
-      { className: 'flex items-center gap-3' },
-      // Busqueda con icono
+  // Card para vista móvil
+  const mobileRender = useCallback(
+    (contact: Contact) =>
       React.createElement(
         'div',
-        { className: 'relative flex-1' },
-        React.createElement(UI.DynamicIcon, {
-          icon: 'Search',
-          size: 16,
-          className: 'absolute left-3 top-1/2 -translate-y-1/2 text-cg-text-muted',
-        }),
-        React.createElement(UI.Input, {
-          type: 'text',
-          placeholder: 'Buscar contactos...',
-          value: searchValue,
-          onChange: handleSearch,
-          className: 'pl-10',
-        })
-      ),
-      // Filtro de tipo
-      React.createElement(
-        UI.ButtonGroup,
-        null,
-        ['', 'person', 'company', 'other'].map((type) =>
-          React.createElement(
-            UI.ButtonGroupItem,
-            {
-              key: type,
-              active: activeTypeFilter === type,
-              onClick: () => handleTypeFilter(type),
-            },
-            type === '' ? 'Todos' : formatType(type)
-          )
-        )
-      )
-    ),
-
-    // Tabla
-    React.createElement(
-      UI.Table,
-      null,
-      // Header
-      React.createElement(
-        UI.TableHeader,
-        null,
+        { className: 'flex flex-col gap-1' },
+        // Nombre
+        React.createElement('span', { className: 'font-medium text-sm' }, contact.name),
+        // Tipo · Teléfono
         React.createElement(
-          UI.TableRow,
-          null,
-          selectable &&
-            React.createElement(
-              UI.TableHead,
-              { className: 'w-10' },
-              React.createElement(UI.Checkbox, {
-                checked: data.length > 0 && data.every((c) => selectedIds.has(c.id)),
-                onCheckedChange: () => toggleAllSelection(),
-              })
-            ),
-          allColumns.map((col) =>
-            React.createElement(
-              UI.TableHead,
-              {
-                key: col.key,
-                sortDirection: getSortDirection(col.key),
-                onSort: () => handleSort(col.key),
-                className: col.className,
-              },
-              col.header
-            )
-          ),
-          extraActions.length > 0 &&
-            React.createElement(UI.TableHead, { className: 'w-24 text-right' }, 'Acciones')
-        )
-      ),
-      // Body
-      React.createElement(
-        UI.TableBody,
-        null,
-        loading
-          ? Array.from({ length: 5 }).map((_, i) =>
-              React.createElement(
-                UI.TableRow,
-                { key: `skeleton-${i}` },
-                Array.from({ length: totalColSpan }).map((_, j) =>
-                  React.createElement(
-                    UI.TableCell,
-                    { key: j },
-                    React.createElement(UI.Skeleton, { className: 'h-4' })
-                  )
-                )
-              )
-            )
-          : data.length === 0
-            ? React.createElement(
-                UI.TableRow,
-                null,
-                React.createElement(
-                  UI.TableCell,
-                  { colSpan: totalColSpan, className: 'p-0' },
-                  React.createElement(UI.EmptyState, { title: emptyMessage })
-                )
-              )
-            : data.map((contact) =>
-                React.createElement(
-                  UI.TableRow,
-                  {
-                    key: contact.id,
-                    onClick: onRowClick ? () => onRowClick(contact) : undefined,
-                    className: `${
-                      onRowClick ? 'cursor-pointer' : ''
-                    } ${selectedIds.has(contact.id) ? 'bg-cg-accent-bg' : ''}`,
-                  },
-                  selectable &&
-                    React.createElement(
-                      UI.TableCell,
-                      {
-                        className: 'w-10',
-                        onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
-                      },
-                      React.createElement(UI.Checkbox, {
-                        checked: selectedIds.has(contact.id),
-                        onCheckedChange: () => toggleSelection(contact.id),
-                      })
-                    ),
-                  allColumns.map((col) =>
-                    React.createElement(
-                      UI.TableCell,
-                      { key: col.key, className: col.className },
-                      col.render
-                        ? (col.render(contact) as React.ReactNode)
-                        : (((contact as unknown as Record<string, unknown>)[
-                            col.key
-                          ] as React.ReactNode) ?? '—')
-                    )
-                  ),
-                  extraActions.length > 0 &&
-                    React.createElement(
-                      UI.TableCell,
-                      {
-                        className: 'text-right',
-                        onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
-                      },
-                      React.createElement(
-                        'div',
-                        { className: 'flex items-center justify-end gap-1' },
-                        extraActions
-                          .filter((a) => !a.hidden || !a.hidden(contact))
-                          .map((action, i) =>
-                            React.createElement(
-                              UI.Button,
-                              {
-                                key: i,
-                                variant: action.variant === 'destructive' ? 'destructive' : 'ghost',
-                                size: 'xs',
-                                onClick: () => action.onClick(contact),
-                                title: action.label,
-                              },
-                              action.label
-                            )
-                          )
-                      )
-                    )
-                )
-              )
-      )
-    ),
-
-    // Paginación
-    !loading &&
-      data.length > 0 &&
-      React.createElement(
-        'div',
-        { className: 'flex items-center justify-between' },
-        React.createElement(
-          'span',
-          { className: 'text-xs text-cg-text-muted' },
-          `${(pagination.page - 1) * pagination.pageSize + 1}–${Math.min(pagination.page * pagination.pageSize, pagination.total)} de ${pagination.total}`
+          'div',
+          { className: 'text-xs', style: { color: 'var(--cg-text-muted)' } },
+          [formatType(contact.type), contact.phone].filter(Boolean).join(' · ')
         ),
-        React.createElement(
-          UI.Pagination,
-          null,
+        // Email
+        contact.email &&
           React.createElement(
-            UI.PaginationContent,
-            null,
-            React.createElement(UI.PaginationPrevious, {
-              onClick: prevPage,
-              disabled: pagination.page <= 1,
-            }),
-            ...Array.from({ length: pagination.totalPages }, (_, i) => {
-              const page = i + 1;
-              // Mostrar primera, última, y ±1 de la actual; el resto ellipsis
-              const isCurrent = page === pagination.page;
-              const isNearCurrent = Math.abs(page - pagination.page) <= 1;
-              const isEdge = page === 1 || page === pagination.totalPages;
-
-              if (isCurrent || isNearCurrent || isEdge) {
-                return React.createElement(
-                  UI.PaginationItem,
-                  { key: page },
-                  React.createElement(
-                    UI.PaginationLink,
-                    {
-                      isActive: isCurrent,
-                      onClick: () => goToPage(page),
-                    },
-                    String(page)
-                  )
-                );
-              }
-              // Ellipsis solo en el primer gap
-              if (page === 2 || page === pagination.totalPages - 1) {
-                return React.createElement(
-                  UI.PaginationItem,
-                  { key: `ellipsis-${page}` },
-                  React.createElement(UI.PaginationEllipsis)
-                );
-              }
-              return null;
-            }).filter(Boolean),
-            React.createElement(UI.PaginationNext, {
-              onClick: nextPage,
-              disabled: pagination.page >= pagination.totalPages,
-            })
+            'div',
+            { className: 'text-xs', style: { color: 'var(--cg-text-muted)' } },
+            contact.email
+          ),
+        // Badge de estado
+        React.createElement(
+          'div',
+          { className: 'mt-1' },
+          React.createElement(
+            UI.Badge,
+            {
+              variant: contact.is_active ? 'success-soft' : 'secondary',
+              size: 'sm',
+            },
+            contact.is_active ? 'Activo' : 'Inactivo'
           )
         )
-      )
+      ),
+    []
   );
+
+  return React.createElement(UI.DataTable, {
+    data,
+    rowKey: (contact: Contact) => contact.id,
+    loading,
+    error: error ?? undefined,
+    onRetry: refetch,
+    columns: dtColumns,
+    searchPlaceholder: 'Buscar contactos...',
+    searchValue,
+    onSearchChange: handleSearch,
+    filterSections: [
+      {
+        label: 'Tipo',
+        options: ['', 'person', 'company', 'other'].map((type) => ({
+          value: type,
+          label: type === '' ? 'Todos' : formatType(type),
+        })),
+        value: activeTypeFilter,
+        onChange: handleTypeFilter,
+      },
+    ],
+    sortKey,
+    sortDirection: sortDir,
+    onSortChange: handleSort,
+    pagination: {
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      total: pagination.total,
+    },
+    onPageChange: goToPage,
+    selectable,
+    selectedIds,
+    onSelectionChange: handleSelectionChange,
+    actions: dtActions,
+    onRowClick,
+    emptyState: {
+      title: emptyMessage,
+      filteredTitle: 'Sin resultados',
+      filteredDescription: 'No se encontraron contactos con los filtros actuales.',
+    },
+    mobileRender,
+    className,
+  });
 }


### PR DESCRIPTION
## Summary
- Migración de ContactsTable a DataTable con `mobileRender` para vista de cards en móvil (#37)
- Agrupación de campos del formulario de contacto en secciones con íconos (#36)

## PRs incluidos
- #37 — refactor: migrate ContactsTable to DataTable with mobileRender
- #36 — feat: group contact form fields into sections with icons

## Test plan
- [ ] Verificar tabla de contactos en desktop (misma funcionalidad)
- [ ] Verificar vista de cards en móvil
- [ ] Verificar formulario de contacto con secciones e íconos
- [ ] Build sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)